### PR TITLE
fix: validate_description to run on bot commits.

### DIFF
--- a/.github/workflows/validate-description.yml
+++ b/.github/workflows/validate-description.yml
@@ -1,7 +1,10 @@
 name: validate description
 
 on:
-  pull_request:
+  # pull_request_target is meant to run on bot commits. 
+  # Do check out and run code from the pull request's head commit. 
+  # It is suitable for this usecase as we are only looking at PR description. 
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 jobs:


### PR DESCRIPTION
## Summary
Currently the validate_description trigger doesn't run when a bot does a commit to a PR. In flow repo, we have bots automatically fixing formatting issues, or doing dummy commits. In those cases, the validate_description check is not run. 
This leads to a forceful manual commit, tests re-run, and waste of time.

## Related Issues
ISS-195199

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Change doesn't affect products or customers
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change (the new functionality and code refactor do not require a migration strategy)
- [ ] Breaking change (fix or feature that will require a migration plan for data or other services)
- [ ] Documentation/comment update
- [ ] Other (please describe):

## Testing Procedure
<!-- Outline the testing process for this PR that others can follow locally.  -->
- 

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] I used generative AI to generate this PR
- [ ] I have self-reviewed my code for clarity and correctness
- [x] I have added or updated comments for complex or non-obvious logic in my code
- [ ] I have updated relevant documentation (e.g., README, code docs)
- [ ] My changes do not introduce new warnings or errors
- [ ] I have added or updated tests to cover new or changed functionality
- [ ] All tests pass locally with my changes applied
