### PR TITLE
allow Team scoped display IDs in PR description check

### DIFF
--- a/checks/check_pr_description.py
+++ b/checks/check_pr_description.py
@@ -6,8 +6,20 @@ def check_description(description):
     Checks if the PR description contains a work item link.
     Returns True if valid, False otherwise.
     """
-    # More flexible regex that handles markdown formatting
-    regex = r"(?:^|[\s\[\(\-\*\>\.]|:\s)(https:\/\/app\.devrev\.ai\/devrev\/works\/)?(ISS|TKT|TASK)-\d+\b"
+    # More flexible regex that handles markdown formatting.
+    # Accepts work item URLs like:
+    # https://app.devrev.ai/devrev/issue/DES-123
+    # https://app.devrev.ai/devrev/works/ISS-123
+    regex = (
+        r"(?:^|[\s\[\(\-\*\>\.]|:\s)"
+        r"(?:"
+        r"(?-i:[A-Z]{3,5})-\d+\b"
+        r"|https:\/\/app\.devrev\.ai\/devrev\/(?:"
+        r"works\/(?-i:[A-Z]{3,5})-\d+\b"
+        r"|issue\/(?-i:[A-Z]{3,5})-\d+\b"
+        r")"
+        r")"
+    )
     return bool(re.search(regex, description, re.IGNORECASE))
 
 def check_description_cli(description):
@@ -20,7 +32,11 @@ def check_description_cli(description):
         print("")
         print("Reason: PR description must include a work item link")
         print("")
-        print("Valid formats: ISS-123, TKT-456, TASK-789, or https://app.devrev.ai/devrev/works/ISS-123")
+        print(
+            "Valid formats: ISS-123, TKT-456, TASK-789, ABC-123, "
+            "https://app.devrev.ai/devrev/works/ISS-123, or "
+            "https://app.devrev.ai/devrev/issue/DES-123"
+        )
         print("Note: Use 'work-item: ISS-123' (space after colon), not 'work-item:ISS-123'")
         sys.exit(1)
     

--- a/checks/fixtures/pr_description/invalid/issue_url_lowercase_key.txt
+++ b/checks/fixtures/pr_description/invalid/issue_url_lowercase_key.txt
@@ -1,0 +1,3 @@
+Tracks work from https://app.devrev.ai/devrev/issue/teams-123.
+
+This should be rejected because the key is lowercase.

--- a/checks/fixtures/pr_description/invalid/wrong_format.txt
+++ b/checks/fixtures/pr_description/invalid/wrong_format.txt
@@ -1,3 +1,3 @@
-This PR addresses issue ISSUE-123 and ticket TICKET-456.
+This PR addresses issue TEAMSSS-123 and ticket TK-456.
 
 The work items don't follow the correct format. 

--- a/checks/fixtures/pr_description/valid/generic_display_id.txt
+++ b/checks/fixtures/pr_description/valid/generic_display_id.txt
@@ -1,0 +1,4 @@
+This PR implements support for TEAMS-123.
+
+## Changes
+- Added validation improvements

--- a/checks/fixtures/pr_description/valid/issue_url_display_id.txt
+++ b/checks/fixtures/pr_description/valid/issue_url_display_id.txt
@@ -1,0 +1,3 @@
+Tracks work from https://app.devrev.ai/devrev/issue/TEAMS-123.
+
+This PR includes associated implementation changes.

--- a/checks/test_checks.py
+++ b/checks/test_checks.py
@@ -98,6 +98,16 @@ class TestPRDescription(unittest.TestCase):
             description = f.read()
         self.assertTrue(checks.check_pr_description.check_description(description))
 
+    def test_valid_generic_display_id(self):
+        with open("checks/fixtures/pr_description/valid/generic_display_id.txt", "r") as f:
+            description = f.read()
+        self.assertTrue(checks.check_pr_description.check_description(description))
+
+    def test_valid_issue_url_display_id(self):
+        with open("checks/fixtures/pr_description/valid/issue_url_display_id.txt", "r") as f:
+            description = f.read()
+        self.assertTrue(checks.check_pr_description.check_description(description))
+
     def test_invalid_no_link(self):
         with open("checks/fixtures/pr_description/invalid/no_link.txt", "r") as f:
             description = f.read()
@@ -105,6 +115,11 @@ class TestPRDescription(unittest.TestCase):
 
     def test_invalid_wrong_format(self):
         with open("checks/fixtures/pr_description/invalid/wrong_format.txt", "r") as f:
+            description = f.read()
+        self.assertFalse(checks.check_pr_description.check_description(description))
+
+    def test_invalid_issue_url_lowercase_key(self):
+        with open("checks/fixtures/pr_description/invalid/issue_url_lowercase_key.txt", "r") as f:
             description = f.read()
         self.assertFalse(checks.check_pr_description.check_description(description))
 


### PR DESCRIPTION
## Summary
- Expand PR description validation to accept generic display IDs in the format `[A-Z]{3,5}-<number>`.
- Support both `https://app.devrev.ai/devrev/works/<ID>` and `https://app.devrev.ai/devrev/issue/<ID>` URL forms.
- Add fixtures and unit tests for new valid/invalid cases, including lowercase-key rejection.

## Related Issues
- work-item: https://app.devrev.ai/devrev/works/ISS-264625

## Type of Change
- [x] Non-breaking change (the new functionality and code refactor do not require a migration strategy)
- [ ] Change doesn't affect products or customers
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that will require a migration plan for data or other services)
- [ ] Documentation/comment update
- [ ] Other (please describe):

## Testing Procedure
- `python3 - <<'PY' ... PY` manual fixture sweep for `checks/fixtures/pr_description/{valid,invalid}`; all cases passed (`ALL_OK=True`).
- Attempted `make tidy vet` per local workflow, but this repository has no `tidy`/`vet` make targets.

## Checklist
- [x] I used generative AI to generate this PR
- [x] I have self-reviewed my code for clarity and correctness
- [ ] I have added or updated comments for complex or non-obvious logic in my code
- [ ] I have updated relevant documentation (e.g., README, code docs)
- [x] My changes do not introduce new warnings or errors
- [x] I have added or updated tests to cover new or changed functionality
- [x] All tests pass locally with my changes applied

Made with [Cursor](https://cursor.com)