### PR TITLE
Allow pnpm lock file in SLA check.

### DIFF
--- a/checks/check_patching_sla.py
+++ b/checks/check_patching_sla.py
@@ -23,7 +23,8 @@ ALLOWED_FILES = [
     "project.pbxproj",
     "uv.lock",
     "Dockerfile*",
-    "Makefile*"
+    "Makefile*",
+    "pnpm-lock.yaml"
 ]
 
 def is_file_allowed(file_path, allowed_patterns):


### PR DESCRIPTION
## Summary
Allow pnpm lock file in SLA check.

## Related Issues
https://app.devrev.ai/devrev/issue/SECOP-70